### PR TITLE
Add support for multiple links in a single table cell and titles in code macros.

### DIFF
--- a/src/main/java/org/radeox/macro/CodeMacro.java
+++ b/src/main/java/org/radeox/macro/CodeMacro.java
@@ -49,7 +49,10 @@ public class CodeMacro extends LocalePreserved {
   private Map formatters;
   private FilterContext nullContext = new BaseFilterContext();
 
-  private String start;
+  private String outerStart;
+  private String innerStart;
+  private String titleStart;
+  private String titleEnd;
   private String end;
 
   public String getLocaleKey() {
@@ -62,8 +65,11 @@ public class CodeMacro extends LocalePreserved {
     String outputName = (String) context.get(RenderContext.OUTPUT_BUNDLE_NAME);
     ResourceBundle outputMessages = ResourceBundle.getBundle(outputName, outputLocale);
 
-    start = outputMessages.getString(getLocaleKey() + ".start");
+    outerStart = outputMessages.getString(getLocaleKey() + ".outer.start");
+    innerStart = outputMessages.getString(getLocaleKey() + ".inner.start");
     end = outputMessages.getString(getLocaleKey() + ".end");
+    titleStart = outputMessages.getString(getLocaleKey() + ".title.start");
+    titleEnd = outputMessages.getString(getLocaleKey() + ".title.end");
   }
 
   public CodeMacro() {
@@ -116,7 +122,13 @@ public class CodeMacro extends LocalePreserved {
 
     String result = formatter.filter(params.getContent(), nullContext);
 
-    writer.write(start);
+    writer.write(outerStart);
+    if (params.get("title")!=null) {
+      writer.write(titleStart);
+      writer.write(params.get("title"));
+      writer.write(titleEnd);
+    }
+    writer.write(innerStart);
     writer.write(replace(result.trim()));
     writer.write(end);
     return;

--- a/src/main/java/org/radeox/macro/table/TableBuilder.java
+++ b/src/main/java/org/radeox/macro/table/TableBuilder.java
@@ -35,14 +35,12 @@ public class TableBuilder {
     String lastToken = null;
     while (tokenizer.hasMoreTokens()) {
       String token = tokenizer.nextToken();
-      String linkToken = "";
-      if(token.indexOf('[') != -1 && token.indexOf(']') == -1) {
-	while(token.indexOf(']') == -1 && tokenizer.hasMoreTokens()) {
-	  linkToken += token;
-	  token = tokenizer.nextToken();
-	}
-	token = linkToken + token;
-      }
+      String linkToken = token;
+			while(linkToken.split("\\[").length != linkToken.split("\\]").length && tokenizer.hasMoreTokens()) {
+				token = tokenizer.nextToken();
+				linkToken += token;
+			}
+			token = linkToken;
       if ("\n".equals(token)) {
         // Handles "\n" - "|\n"
         if (null == lastToken || "|".equals(lastToken)) {

--- a/src/main/java/org/radeox/macro/table/TableBuilder.java
+++ b/src/main/java/org/radeox/macro/table/TableBuilder.java
@@ -35,12 +35,14 @@ public class TableBuilder {
     String lastToken = null;
     while (tokenizer.hasMoreTokens()) {
       String token = tokenizer.nextToken();
-      String linkToken = token;
-			while(linkToken.split("\\[").length != linkToken.split("\\]").length && tokenizer.hasMoreTokens()) {
-				token = tokenizer.nextToken();
-				linkToken += token;
-			}
-			token = linkToken;
+      String linkToken = "";
+      if(token.indexOf('[') != -1 && token.indexOf(']') == -1) {
+        while(token.indexOf(']') == -1 && tokenizer.hasMoreTokens()) {
+          linkToken += token;
+          token = tokenizer.nextToken();
+        }
+      token = linkToken + token;
+      }
       if ("\n".equals(token)) {
         // Handles "\n" - "|\n"
         if (null == lastToken || "|".equals(lastToken)) {

--- a/src/main/resources/radeox_markup.properties
+++ b/src/main/resources/radeox_markup.properties
@@ -17,7 +17,10 @@ macro.rfc.name=rfc
 macro.table.name=table
 macro.xref.name=xref
 
-macro.code.start=<div class=\"code\"><pre>
+macro.code.title.start=<div class=\"codeHeader\">
+macro.code.title.end=</div>
+macro.code.outer.start=<div class=\"code\">
+macro.code.inner.start=<pre>
 macro.code.end=</pre></div>
 
 #Filters

--- a/src/test/java/org/radeox/macro/TableMacroTest.java
+++ b/src/test/java/org/radeox/macro/TableMacroTest.java
@@ -61,4 +61,9 @@ public class TableMacroTest extends MacroTestSupport {
     assertEquals("<table class=\"wiki-table\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\"><tr><th>1</th><th>2</th></tr><tr class=\"table-odd\"><td>4</td><td>2.5</td></tr></table>", result);
   }
 
+	/*public void testDoubleLinks() {
+    String result = engine.render("{table}1|2\nlink|[here|http://grails.org] [hereAlso|http://grails.org]{table}", context);
+    assertEquals("<table class=\"wiki-table\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\"><tr><th>1</th><th>2</th></tr><tr class=\"table-odd\"><td>link</td><td><span class=\"nobr\"><a href=\"http://grails.org\">here</a></span> <span class=\"nobr\"><a href=\"http://grails.org\">hereAlso</a></span></td></tr></table>", result);
+  }*/
+
 }


### PR DESCRIPTION
Added [] balancing to a single table cell to support multiple links by counting the number of occurrences of [ and ] and matching them.  Added a unit test, but couldn't figure out easily how to render [link|links] in table macro tests, so it is commented out for now.

Also added title support for the code macro as this is something we like from jira/confluence.
